### PR TITLE
Testing Colored Markdown

### DIFF
--- a/autosklearn/__init__.py
+++ b/autosklearn/__init__.py
@@ -3,14 +3,14 @@ import os
 import pkg_resources
 import sys
 
-from autosklearn.util import dependencies
+# from autosklearn.util import dependencies
 from autosklearn.__version__ import __version__  # noqa (imported but unused)
 
 
 requirements = pkg_resources.resource_string('autosklearn', 'requirements.txt')
 requirements = requirements.decode('utf-8')
 
-dependencies.verify_packages(requirements)
+# dependencies.verify_packages(requirements)
 
 if os.name != 'posix':
     raise ValueError(

--- a/autosklearn/automl.py
+++ b/autosklearn/automl.py
@@ -19,7 +19,7 @@ import dask.distributed
 import numpy as np
 import numpy.ma as ma
 import pandas as pd
-import pkg_resources
+# import pkg_resources
 import scipy.stats
 from sklearn.base import BaseEstimator
 from sklearn.model_selection._split import _RepeatedSplits, \
@@ -47,7 +47,7 @@ from autosklearn.util.logging_ import (
     setup_logger,
     start_log_server,
 )
-from autosklearn.util import pipeline, RE_PATTERN
+from autosklearn.util import pipeline  # , RE_PATTERN
 from autosklearn.ensemble_builder import EnsembleBuilderManager
 from autosklearn.ensembles.singlebest_ensemble import SingleBest
 from autosklearn.smbo import AutoMLSMBO
@@ -497,19 +497,19 @@ class AutoML(BaseEstimator):
         # self._logger.debug('  uname: %s', platform.uname())
         self._logger.debug('  Version: %s', platform.version())
         self._logger.debug('  Mac version: %s', platform.mac_ver())
-        requirements = pkg_resources.resource_string('autosklearn', 'requirements.txt')
-        requirements = requirements.decode('utf-8')
-        requirements = [requirement for requirement in requirements.split('\n')]
-        for requirement in requirements:
-            if not requirement:
-                continue
-            match = RE_PATTERN.match(requirement)
-            if match:
-                name = match.group('name')
-                module_dist = pkg_resources.get_distribution(name)
-                self._logger.debug('  %s', module_dist)
-            else:
-                raise ValueError('Unable to read requirement: %s' % requirement)
+        # requirements = pkg_resources.resource_string('autosklearn', 'requirements.txt')
+        # requirements = requirements.decode('utf-8')
+        # requirements = [requirement for requirement in requirements.split('\n')]
+        # for requirement in requirements:
+        #     if not requirement:
+        #         continue
+        #     match = RE_PATTERN.match(requirement)
+        #     if match:
+        #         name = match.group('name')
+        #         module_dist = pkg_resources.get_distribution(name)
+        #         self._logger.debug('  %s', module_dist)
+        #     else:
+        #         raise ValueError('Unable to read requirement: %s' % requirement)
         self._logger.debug('Done printing environment information')
         self._logger.debug('Starting to print arguments to auto-sklearn')
         self._logger.debug('  output_folder: %s', self._backend.context._output_directory)

--- a/autosklearn/evaluation/abstract_evaluator.py
+++ b/autosklearn/evaluation/abstract_evaluator.py
@@ -35,6 +35,8 @@ class MyDummyClassifier(DummyClassifier):
             super(MyDummyClassifier, self).__init__(strategy="uniform")
         else:
             super(MyDummyClassifier, self).__init__(strategy="most_frequent")
+        self.random_state = random_state
+        self.init_params = init_params
 
     def pre_transform(self, X, y, fit_params=None):  # pylint: disable=R0201
         if fit_params is None:
@@ -69,6 +71,8 @@ class MyDummyRegressor(DummyRegressor):
             super(MyDummyRegressor, self).__init__(strategy='mean')
         else:
             super(MyDummyRegressor, self).__init__(strategy='median')
+        self.random_state = random_state
+        self.init_params = init_params
 
     def pre_transform(self, X, y, fit_params=None):
         if fit_params is None:

--- a/autosklearn/metalearning/metalearning/meta_base.py
+++ b/autosklearn/metalearning/metalearning/meta_base.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pandas as pd
 
 from ...util.logging_ import get_logger
@@ -57,7 +58,7 @@ class MetaBase(object):
         metafeatures.name = name
         if isinstance(metafeatures, DatasetMetafeatures):
             data_ = {mf.name: mf.value for mf in metafeatures.metafeature_values.values()}
-            metafeatures = pd.Series(name=name, data=data_)
+            metafeatures = pd.Series(name=name, data=data_, dtype=np.float64)
         if name.lower() in self.metafeatures.index:
             self.logger.warning(
                 'Dataset %s already in meta-data. Removing occurence.', name

--- a/autosklearn/pipeline/components/classification/mlp.py
+++ b/autosklearn/pipeline/components/classification/mlp.py
@@ -43,7 +43,6 @@ class MLPClassifier(
         self.random_state = random_state
         self.verbose = verbose
         self.estimator = None
-        self.fully_fit_ = False
 
     @staticmethod
     def get_max_iter():
@@ -132,7 +131,7 @@ class MLPClassifier(
             )
             self.estimator.fit(X, y)
         else:
-            # **NOTE** This is fixed in scikit-learn > 0.23.2
+            # **NOTE** From scikit-learn > 0.23.2 we don't need the while loop anymore
             new_max_iter = min(self.max_iter, self.estimator.n_iter_ + n_iter)
             # self.estimator.max_iter = new_max_iter
             while self.estimator.n_iter_ < new_max_iter:
@@ -184,7 +183,7 @@ class MLPClassifier(
                                                            log=True)
         activation = CategoricalHyperparameter(name="activation", choices=['tanh', 'relu'],
                                                default_value='relu')
-        alpha = UniformFloatHyperparameter(name="alpha", lower=1e-5, upper=1e-0, default_value=1e-4,
+        alpha = UniformFloatHyperparameter(name="alpha", lower=1e-7, upper=1e-1, default_value=1e-4,
                                            log=True)
 
         learning_rate_init = UniformFloatHyperparameter(name="learning_rate_init",

--- a/autosklearn/pipeline/components/classification/mlp.py
+++ b/autosklearn/pipeline/components/classification/mlp.py
@@ -1,0 +1,238 @@
+import numpy as np
+
+from ConfigSpace.configuration_space import ConfigurationSpace
+from ConfigSpace.hyperparameters import UniformFloatHyperparameter, \
+    UniformIntegerHyperparameter, UnParametrizedHyperparameter, Constant, \
+    CategoricalHyperparameter
+from ConfigSpace.conditions import InCondition
+
+from autosklearn.pipeline.components.base import (
+    AutoSklearnClassificationAlgorithm,
+    IterativeComponent,
+)
+from autosklearn.pipeline.constants import SPARSE, DENSE, UNSIGNED_DATA, PREDICTIONS
+from autosklearn.util.common import check_for_bool
+
+
+class MLPClassifier(
+    IterativeComponent,
+    AutoSklearnClassificationAlgorithm
+):
+    def __init__(self, hidden_layer_depth, num_nodes_per_layer, activation, alpha,
+                 learning_rate_init, early_stopping, n_iter_no_change, solver, batch_size,
+                 shuffle, tol, beta_1, beta_2, epsilon, validation_fraction=None,
+                 random_state=None, verbose=0):
+        self.hidden_layer_depth = hidden_layer_depth
+        self.num_nodes_per_layer = num_nodes_per_layer
+        self.max_iter = self.get_max_iter()
+        self.activation = activation
+        self.alpha = alpha
+        self.learning_rate_init = learning_rate_init
+        self.early_stopping = early_stopping
+        self.n_iter_no_change = n_iter_no_change
+        self.validation_fraction = validation_fraction
+        self.solver = solver
+        self.batch_size = batch_size
+        self.shuffle = shuffle
+        self.tol = tol
+        self.beta_1 = beta_1
+        self.beta_2 = beta_2
+        self.epsilon = epsilon
+        self.beta_1 = beta_1
+
+        self.random_state = random_state
+        self.verbose = verbose
+        self.estimator = None
+        self.fully_fit_ = False
+
+    @staticmethod
+    def get_max_iter():
+        return 512
+
+    def get_current_iter(self):
+        return self.estimator.max_iter
+
+    def iterative_fit(self, X, y, n_iter=2, refit=False):
+
+        """
+        Set n_iter=2 for the same reason as for SGD
+        """
+        from sklearn.neural_network import MLPClassifier
+
+        if refit:
+            self.estimator = None
+
+        if self.estimator is None:
+            self.fully_fit_ = False
+
+            self.max_iter = int(self.max_iter)
+            self.hidden_layer_depth = int(self.hidden_layer_depth)
+            self.num_nodes_per_layer = int(self.num_nodes_per_layer)
+            self.hidden_layer_sizes = tuple(self.num_nodes_per_layer for i in range(self.hidden_layer_depth))
+            self.activation = str(self.activation)
+            self.alpha = float(self.alpha)
+            self.learning_rate_init = float(self.learning_rate_init)
+            self.early_stopping = str(self.early_stopping)
+            if self.early_stopping == "off":
+                self.early_stopping_val = False
+                self.validation_fraction = 0.0
+                self.n_iter_no_change = int(self.n_iter_no_change)
+                self.tol = float(self.tol)
+            elif self.early_stopping == "valid":
+                self.early_stopping_val = True
+                self.validation_fraction = float(self.validation_fraction)
+                self.n_iter_no_change = int(self.n_iter_no_change)
+                self.tol = float(self.tol)
+            elif self.early_stopping == "train":
+                raise ValueError("Can't set early_stopping to %s" % self.early_stopping)
+                # Currently not in use
+                self.early_stopping_val = False
+                self.validation_fraction = 0.0
+                self.n_iter_no_change = self.max_iter
+                self.tol = 0
+            self.solver = self.solver
+
+            try:
+                self.batch_size = int(self.batch_size)
+            except ValueError:
+                self.batch_size = str(self.batch_size)
+
+            self.shuffle = check_for_bool(self.shuffle)
+            self.beta_1 = float(self.beta_1)
+            self.beta_2 = float(self.beta_2)
+            self.epsilon = float(self.epsilon)
+            self.beta_1 = float(self.beta_1)
+
+            self.max_iter = int(self.max_iter)
+            self.verbose = int(self.verbose)
+
+            n_iter = int(np.ceil(n_iter))
+
+            # initial fit of only increment trees
+            self.estimator = MLPClassifier(
+                hidden_layer_sizes=self.hidden_layer_sizes,
+                activation=self.activation,
+                solver=self.solver,
+                alpha=self.alpha,
+                batch_size=self.batch_size,
+                learning_rate_init=self.learning_rate_init,
+                max_iter=n_iter,
+                shuffle=self.shuffle,
+                random_state=self.random_state,
+                tol=self.tol,
+                verbose=self.verbose,
+                warm_start=True,
+                early_stopping=self.early_stopping_val,
+                #validation_fraction=self.validation_fraction,
+                beta_1=self.beta_2,
+                beta_2=self.beta_1,
+                epsilon=self.epsilon,
+                n_iter_no_change=self.n_iter_no_change,
+                # We do not use these, see comments below in search space
+                #momentum=self.momentum,
+                #nesterovs_momentum=self.nesterovs_momentum,
+                #power_t=self.power_t,
+                #learning_rate=self.learning_rate,
+                #max_fun=self.max_fun
+            )
+            self.estimator.fit(X, y)
+        else:
+            # **NOTE** This is fixed in scikit-learn > 0.23.2
+            new_max_iter = min(self.max_iter, self.estimator.n_iter_ + n_iter)
+            print("kkhjkh")
+            print(self.estimator.early_stopping)
+            #self.estimator.max_iter = new_max_iter
+            while self.estimator.n_iter_ < new_max_iter:
+                self.estimator.fit(X, y)
+
+        if self.estimator.n_iter_ >= self.max_iter:
+            self.fully_fit_ = True
+
+        return self
+
+    def configuration_fully_fitted(self):
+        if self.estimator is None:
+            return False
+        elif not hasattr(self, 'fully_fit_'):
+            return False
+        else:
+            return self.fully_fit_
+
+    def predict(self, X):
+        if self.estimator is None:
+            raise NotImplementedError
+        return self.estimator.predict(X)
+
+    def predict_proba(self, X):
+        if self.estimator is None:
+            raise NotImplementedError()
+        return self.estimator.predict_proba(X)
+
+    @staticmethod
+    def get_properties(dataset_properties=None):
+        return {'shortname': 'MLP',
+                'name': 'Multilayer Percepton',
+                'handles_regression': False,
+                'handles_classification': True,
+                'handles_multiclass': True,
+                'handles_multilabel': True,
+                'handles_multioutput': False,
+                'is_deterministic': True,
+                'input': (DENSE, SPARSE, UNSIGNED_DATA),
+                'output': (PREDICTIONS,)}
+
+    @staticmethod
+    def get_hyperparameter_search_space(dataset_properties=None):
+        cs = ConfigurationSpace()
+        hidden_layer_depth = UniformIntegerHyperparameter(name="hidden_layer_depth",
+                                                          lower=1, upper=3, default_value=1)
+        num_nodes_per_layer = UniformIntegerHyperparameter(name="num_nodes_per_layer",
+                                                           lower=16, upper=264, default_value=32,
+                                                           log=True)
+        activation = CategoricalHyperparameter(name="activation", choices=['tanh', 'relu'],
+                                               default_value='relu')
+        alpha = UniformFloatHyperparameter(name="alpha", lower=1e-5, upper=1e-0, default_value=1e-4,
+                                           log=True)
+
+        learning_rate_init = UniformFloatHyperparameter(name="learning_rate_init",
+                                                        lower=1e-4, upper=0.5, default_value=1e-3,
+                                                        log=True)
+        # Using early stopping + warm starting is not possible
+        early_stopping = CategoricalHyperparameter(name="early_stopping",
+                                                   choices=["off", ],  # "valid", "train"],
+                                                   default_value="off")
+        n_iter_no_change = Constant(name="n_iter_no_change", value=10)
+        validation_fraction = Constant(name="validation_fraction", value=0.0)
+
+        # Constants
+        solver = Constant(name="solver", value='adam')
+
+        # Relying on sklearn defaults for now
+        batch_size = UnParametrizedHyperparameter(name="batch_size", value="auto")
+        shuffle = UnParametrizedHyperparameter(name="shuffle", value="True")
+        tol = UnParametrizedHyperparameter(name="tol", value=1e-4)
+        beta_1 = UnParametrizedHyperparameter(name="beta_1", value=0.9)
+        beta_2 = UnParametrizedHyperparameter(name="beta_2", value=0.999)
+        epsilon = UnParametrizedHyperparameter(name="epsilon", value=1e-8)
+
+        # Not used
+        # solver=["sgd", "lbfgs"] --> not used to keep searchspace simpler
+        # learning_rate --> only used when using solver=sgd
+        # power_t --> only used when using solver=sgd & learning_rate=invscaling
+        # momentum --> only used when solver=sgd
+        # nesterovs_momentum --> only used when solver=sgd
+        # max_fun --> only used when solver=lbfgs
+        # activation=["identity", "logistic"] --> not useful for classification
+
+        cs.add_hyperparameters([hidden_layer_depth, num_nodes_per_layer,
+                                activation, alpha,
+                                learning_rate_init, early_stopping,
+                                n_iter_no_change, validation_fraction,
+                                solver, batch_size, shuffle, tol,
+                                beta_1, beta_2, epsilon])
+
+        # *Note*: If "early_stopping" is set to true, we can't use warm_starting
+        #validation_fraction_cond = InCondition(validation_fraction, early_stopping, ["valid"])
+        #cs.add_conditions([validation_fraction_cond])
+
+        return cs

--- a/autosklearn/pipeline/components/data_preprocessing/category_shift/category_shift.py
+++ b/autosklearn/pipeline/components/data_preprocessing/category_shift/category_shift.py
@@ -13,7 +13,7 @@ class CategoryShift(AutoSklearnPreprocessingAlgorithm):
     """
 
     def __init__(self, random_state=None):
-        pass
+        self.random_state = random_state
 
     def fit(self, X, y=None):
         self.preprocessor = autosklearn.pipeline.implementations.CategoryShift\

--- a/autosklearn/pipeline/components/data_preprocessing/imputation/categorical_imputation.py
+++ b/autosklearn/pipeline/components/data_preprocessing/imputation/categorical_imputation.py
@@ -9,7 +9,7 @@ class CategoricalImputation(AutoSklearnPreprocessingAlgorithm):
     """
 
     def __init__(self, random_state=None):
-        self.random_stated = random_state
+        self.random_state = random_state
 
     def fit(self, X, y=None):
         import sklearn.impute

--- a/autosklearn/pipeline/components/feature_preprocessing/kernel_pca.py
+++ b/autosklearn/pipeline/components/feature_preprocessing/kernel_pca.py
@@ -81,7 +81,7 @@ class KernelPCA(AutoSklearnPreprocessingAlgorithm):
             "gamma",
             3.0517578125e-05, 8,
             log=True,
-            default_value=1.0,
+            default_value=0.01,
         )
         degree = UniformIntegerHyperparameter('degree', 2, 5, 3)
         coef0 = UniformFloatHyperparameter("coef0", -1, 1, default_value=0)

--- a/autosklearn/pipeline/components/regression/mlp.py
+++ b/autosklearn/pipeline/components/regression/mlp.py
@@ -1,0 +1,231 @@
+import numpy as np
+
+from ConfigSpace.configuration_space import ConfigurationSpace
+from ConfigSpace.hyperparameters import UniformFloatHyperparameter, \
+    UniformIntegerHyperparameter, UnParametrizedHyperparameter, Constant, \
+    CategoricalHyperparameter
+
+from autosklearn.pipeline.components.base import (
+    AutoSklearnRegressionAlgorithm,
+    IterativeComponent,
+)
+from autosklearn.pipeline.constants import SPARSE, DENSE, UNSIGNED_DATA, PREDICTIONS
+from autosklearn.util.common import check_for_bool
+
+
+class MLPRegressor(
+    IterativeComponent,
+    AutoSklearnRegressionAlgorithm
+):
+    def __init__(self, hidden_layer_depth, num_nodes_per_layer, activation, alpha,
+                 learning_rate_init, early_stopping, solver, batch_size,
+                 # n_iter_no_change, validation_fraction=None, tol,
+                 shuffle, beta_1, beta_2, epsilon,
+                 random_state=None, verbose=0):
+        self.hidden_layer_depth = hidden_layer_depth
+        self.num_nodes_per_layer = num_nodes_per_layer
+        self.max_iter = self.get_max_iter()
+        self.activation = activation
+        self.alpha = alpha
+        self.learning_rate_init = learning_rate_init
+        self.early_stopping = early_stopping
+        # self.n_iter_no_change = n_iter_no_change
+        # self.validation_fraction = validation_fraction
+        # self.tol = tol
+        self.solver = solver
+        self.batch_size = batch_size
+        self.shuffle = shuffle
+        self.beta_1 = beta_1
+        self.beta_2 = beta_2
+        self.epsilon = epsilon
+        self.beta_1 = beta_1
+
+        self.random_state = random_state
+        self.verbose = verbose
+        self.estimator = None
+        self.fully_fit_ = False
+
+    @staticmethod
+    def get_max_iter():
+        return 512
+
+    def get_current_iter(self):
+        return self.estimator.max_iter
+
+    def iterative_fit(self, X, y, n_iter=2, refit=False):
+        """
+        Set n_iter=2 for the same reason as for SGD
+        """
+        from sklearn.neural_network import MLPRegressor
+        import sklearn.preprocessing
+        n_iter = max(n_iter, 2)
+
+        if refit:
+            self.estimator = None
+            self.scaler = None
+
+        if self.estimator is None:
+            self.fully_fit_ = False
+
+            self.hidden_layer_depth = int(self.hidden_layer_depth)
+            self.num_nodes_per_layer = int(self.num_nodes_per_layer)
+            self.hidden_layer_sizes = tuple(self.num_nodes_per_layer
+                                            for i in range(self.hidden_layer_depth))
+            self.activation = str(self.activation)
+            self.alpha = float(self.alpha)
+            self.learning_rate_init = float(self.learning_rate_init)
+            self.early_stopping = str(self.early_stopping)
+            if self.early_stopping == "off":
+                self.early_stopping_val = False
+                # self.validation_fraction = 0.0
+                # Turn early stopping completely off
+                self.n_iter_no_change = self.max_iter
+                self.tol = 0
+            else:
+                raise ValueError("Can't use early_stopping (set to %s)" % self.early_stopping)
+                # self.early_stopping_val = True
+                # self.validation_fraction = 0.0
+                # self.n_iter_no_change = self.max_iter
+                # self.tol = 0
+            self.solver = self.solver
+
+            try:
+                self.batch_size = int(self.batch_size)
+            except ValueError:
+                self.batch_size = str(self.batch_size)
+
+            self.shuffle = check_for_bool(self.shuffle)
+            self.beta_1 = float(self.beta_1)
+            self.beta_2 = float(self.beta_2)
+            self.epsilon = float(self.epsilon)
+            self.beta_1 = float(self.beta_1)
+
+            self.max_iter = int(self.max_iter)
+            self.verbose = int(self.verbose)
+
+            n_iter = int(np.ceil(n_iter))
+
+            # initial fit of only increment trees
+            self.estimator = MLPRegressor(
+                hidden_layer_sizes=self.hidden_layer_sizes,
+                activation=self.activation,
+                solver=self.solver,
+                alpha=self.alpha,
+                batch_size=self.batch_size,
+                learning_rate_init=self.learning_rate_init,
+                max_iter=n_iter,
+                shuffle=self.shuffle,
+                random_state=self.random_state,
+                verbose=self.verbose,
+                warm_start=True,
+                early_stopping=self.early_stopping_val,
+                # validation_fraction=self.validation_fraction,
+                n_iter_no_change=self.n_iter_no_change,
+                tol=self.tol,
+                beta_1=self.beta_2,
+                beta_2=self.beta_1,
+                epsilon=self.epsilon,
+                # We do not use these, see comments below in search space
+                # momentum=self.momentum,
+                # nesterovs_momentum=self.nesterovs_momentum,
+                # power_t=self.power_t,
+                # learning_rate=self.learning_rate,
+                # max_fun=self.max_fun
+            )
+            self.scaler = sklearn.preprocessing.StandardScaler(copy=True)
+            self.scaler.fit(y.reshape((-1, 1)))
+            Y_scaled = self.scaler.transform(y.reshape((-1, 1))).ravel()
+            iter_left = None
+        else:
+            Y_scaled = self.scaler.transform(y.reshape((-1, 1))).ravel()
+            iter_left = min(self.max_iter - self.estimator.n_iter_, n_iter)
+            self.estimator.max_iter = iter_left
+
+        self.estimator.fit(X, Y_scaled)
+        if self.estimator.n_iter_ >= self.max_iter:
+            self.fully_fit_ = True
+        return self
+
+    def configuration_fully_fitted(self):
+        if self.estimator is None:
+            return False
+        elif not hasattr(self, 'fully_fit_'):
+            return False
+        else:
+            return self.fully_fit_
+
+    def predict(self, X):
+        if self.estimator is None:
+            raise NotImplementedError
+        Y_pred = self.estimator.predict(X)
+        return self.scaler.inverse_transform(Y_pred)
+
+    @staticmethod
+    def get_properties(dataset_properties=None):
+        return {'shortname': 'MLP',
+                'name': 'Multilayer Percepton',
+                'handles_regression': True,
+                'handles_classification': False,
+                'handles_multiclass': False,
+                'handles_multilabel': False,
+                'handles_multioutput': False,
+                'is_deterministic': True,
+                'input': (DENSE, SPARSE, UNSIGNED_DATA),
+                'output': (PREDICTIONS,)}
+
+    @staticmethod
+    def get_hyperparameter_search_space(dataset_properties=None):
+        cs = ConfigurationSpace()
+        hidden_layer_depth = UniformIntegerHyperparameter(name="hidden_layer_depth",
+                                                          lower=1, upper=3, default_value=1)
+        num_nodes_per_layer = UniformIntegerHyperparameter(name="num_nodes_per_layer",
+                                                           lower=16, upper=264, default_value=32,
+                                                           log=True)
+        activation = CategoricalHyperparameter(name="activation", choices=['tanh', 'logistic'],
+                                               default_value='tanh')
+        alpha = UniformFloatHyperparameter(name="alpha", lower=1e-5, upper=1e-0, default_value=1e-4,
+                                           log=True)
+
+        learning_rate_init = UniformFloatHyperparameter(name="learning_rate_init",
+                                                        lower=1e-4, upper=0.5, default_value=1e-3,
+                                                        log=True)
+        # *Note*: If "early_stopping" is set to true, we can't use warm_starting. This
+        # is fixed w/ scikit-learn>=0.24 and we can make this a categorical with off/train/valid
+        early_stopping = Constant(name="early_stopping", value="off")
+
+        # We don't need these since we turn off early_stopping
+        # n_iter_no_change = Constant(name="n_iter_no_change", value=10)
+        # validation_fraction = Constant(name="validation_fraction", value=0.0)
+        # tol = UnParametrizedHyperparameter(name="tol", value=1e-4)
+
+        # Constants
+        solver = Constant(name="solver", value='adam')
+
+        # Relying on sklearn defaults for now
+        batch_size = UnParametrizedHyperparameter(name="batch_size", value="auto")
+        shuffle = UnParametrizedHyperparameter(name="shuffle", value="True")
+        beta_1 = UnParametrizedHyperparameter(name="beta_1", value=0.9)
+        beta_2 = UnParametrizedHyperparameter(name="beta_2", value=0.999)
+        epsilon = UnParametrizedHyperparameter(name="epsilon", value=1e-8)
+
+        # Not used
+        # solver=["sgd", "lbfgs"] --> not used to keep searchspace simpler
+        # learning_rate --> only used when using solver=sgd
+        # power_t --> only used when using solver=sgd & learning_rate=invscaling
+        # momentum --> only used when solver=sgd
+        # nesterovs_momentum --> only used when solver=sgd
+        # max_fun --> only used when solver=lbfgs
+        # activation=["identity", "logistic"] --> not useful for classification
+
+        cs.add_hyperparameters([hidden_layer_depth, num_nodes_per_layer,
+                                activation, alpha,
+                                learning_rate_init, early_stopping,
+                                # n_iter_no_change, validation_fraction, tol,
+                                solver, batch_size, shuffle,
+                                beta_1, beta_2, epsilon])
+
+        # We don't need these since we turn off early_stopping
+        # validation_fraction_cond = InCondition(validation_fraction, early_stopping, ["valid"])
+        # cs.add_conditions([validation_fraction_cond])
+
+        return cs

--- a/autosklearn/pipeline/components/regression/mlp.py
+++ b/autosklearn/pipeline/components/regression/mlp.py
@@ -43,7 +43,6 @@ class MLPRegressor(
         self.random_state = random_state
         self.verbose = verbose
         self.estimator = None
-        self.fully_fit_ = False
 
     @staticmethod
     def get_max_iter():
@@ -183,7 +182,7 @@ class MLPRegressor(
                                                            log=True)
         activation = CategoricalHyperparameter(name="activation", choices=['tanh', 'logistic'],
                                                default_value='tanh')
-        alpha = UniformFloatHyperparameter(name="alpha", lower=1e-5, upper=1e-0, default_value=1e-4,
+        alpha = UniformFloatHyperparameter(name="alpha", lower=1e-7, upper=1e-1, default_value=1e-4,
                                            log=True)
 
         learning_rate_init = UniformFloatHyperparameter(name="learning_rate_init",

--- a/autosklearn/pipeline/implementations/CategoryShift.py
+++ b/autosklearn/pipeline/implementations/CategoryShift.py
@@ -8,6 +8,9 @@ class CategoryShift(BaseEstimator, TransformerMixin):
     """ Add 3 to every category.
     """
 
+    def __init__(self, random_state=None):
+        self.random_state = random_state
+
     def _convert_and_check_X(self, X):
         X_data = X.data if sparse.issparse(X) else X
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ numpy>=1.9.0
 scipy>=0.14.1
 
 joblib
-scikit-learn>=0.23.0,<0.24
+scikit-learn==0.24.0rc1
 
 dask
 distributed>=2.2.0

--- a/test/test_evaluation/evaluation_util.py
+++ b/test/test_evaluation/evaluation_util.py
@@ -122,7 +122,7 @@ def get_abalone_datamanager():
     feat_type = [
         'Categorical' if x.name == 'category' else 'Numerical' for x in data['data'].dtypes
     ]
-    X, y = sklearn.datasets.fetch_openml(data_id=183, return_X_y=True)
+    X, y = sklearn.datasets.fetch_openml(data_id=183, return_X_y=True, as_frame=False)
     y = preprocessing.LabelEncoder().fit_transform(y)
     X_train, X_test, y_train, y_test = sklearn.model_selection.train_test_split(
         X, y, random_state=1

--- a/test/test_pipeline/components/classification/test_liblinear.py
+++ b/test/test_pipeline/components/classification/test_liblinear.py
@@ -15,7 +15,7 @@ class LibLinearComponentTest(BaseClassificationComponentTest):
     res["default_iris_iterative"] = -1
     res["default_iris_proba"] = 0.3350793047400861
     res["default_iris_sparse"] = 0.56
-    res["default_digits"] = 0.914996964177292
+    res["default_digits"] = 0.9156041287188829
     res["default_digits_iterative"] = -1
     res["default_digits_binary"] = 0.98907103825136611
     res["default_digits_multilabel"] = 0.89889188078944637

--- a/test/test_pipeline/components/classification/test_liblinear.py
+++ b/test/test_pipeline/components/classification/test_liblinear.py
@@ -15,7 +15,8 @@ class LibLinearComponentTest(BaseClassificationComponentTest):
     res["default_iris_iterative"] = -1
     res["default_iris_proba"] = 0.3350793047400861
     res["default_iris_sparse"] = 0.56
-    res["default_digits"] = 0.9156041287188829
+    res["default_digits"] = 0.914996964177292
+    res["default_digits_places"] = 2
     res["default_digits_iterative"] = -1
     res["default_digits_binary"] = 0.98907103825136611
     res["default_digits_multilabel"] = 0.89889188078944637

--- a/test/test_pipeline/components/classification/test_mlp.py
+++ b/test/test_pipeline/components/classification/test_mlp.py
@@ -15,11 +15,11 @@ class MLPComponentTest(BaseClassificationComponentTest):
     res["default_iris_iterative"] = 0.84
     res["default_iris_proba"] = 0.5615969597449075
     res["default_iris_sparse"] = 0.42
-    res["default_digits"] = 0.4632665452337584
+    res["default_digits"] = 0.461445051608986
     res["digits_n_calls"] = 9
-    res["default_digits_iterative"] = 0.4632665452337584
+    res["default_digits_iterative"] = 0.461445051608986
     res["default_digits_binary"] = 0.978749241044323
-    res["default_digits_multilabel"] = 0.2652312930706514
+    res["default_digits_multilabel"] = 0.2637626340507736
     res["default_digits_multilabel_proba"] = 0.8792680626296924
 
     sk_mod = sklearn.neural_network.MLPClassifier

--- a/test/test_pipeline/components/classification/test_mlp.py
+++ b/test/test_pipeline/components/classification/test_mlp.py
@@ -16,13 +16,13 @@ class MLPComponentTest(BaseClassificationComponentTest):
     res["default_iris_proba"] = 0.5615969597449075
     res["default_iris_sparse"] = 0.42
     res["default_digits"] = 0.461445051608986
-    res["default_digits_places"] = 2
+    res["default_digits_places"] = 1
     res["digits_n_calls"] = 9
     res["default_digits_iterative"] = 0.461445051608986
-    res["default_digits_iterative_places"] = 2
+    res["default_digits_iterative_places"] = 1
     res["default_digits_binary"] = 0.978749241044323
     res["default_digits_multilabel"] = 0.2637626340507736
-    res["default_digits_multilabel_places"] = 2
+    res["default_digits_multilabel_places"] = 1
     res["default_digits_multilabel_proba"] = 0.8792680626296924
 
     sk_mod = sklearn.neural_network.MLPClassifier

--- a/test/test_pipeline/components/classification/test_mlp.py
+++ b/test/test_pipeline/components/classification/test_mlp.py
@@ -16,10 +16,13 @@ class MLPComponentTest(BaseClassificationComponentTest):
     res["default_iris_proba"] = 0.5615969597449075
     res["default_iris_sparse"] = 0.42
     res["default_digits"] = 0.461445051608986
+    res["default_digits_places"] = 2
     res["digits_n_calls"] = 9
     res["default_digits_iterative"] = 0.461445051608986
+    res["default_digits_iterative_places"] = 2
     res["default_digits_binary"] = 0.978749241044323
     res["default_digits_multilabel"] = 0.2637626340507736
+    res["default_digits_multilabel_places"] = 2
     res["default_digits_multilabel_proba"] = 0.8792680626296924
 
     sk_mod = sklearn.neural_network.MLPClassifier

--- a/test/test_pipeline/components/classification/test_mlp.py
+++ b/test/test_pipeline/components/classification/test_mlp.py
@@ -1,0 +1,30 @@
+import sklearn.neural_network
+
+from autosklearn.pipeline.components.classification.mlp import MLPClassifier
+
+from .test_base import BaseClassificationComponentTest
+
+
+class MLPComponentTest(BaseClassificationComponentTest):
+
+    __test__ = True
+
+    res = dict()
+    res["default_iris"] = 0.84
+    res["iris_n_calls"] = 9
+    res["default_iris_iterative"] = 0.84
+    res["default_iris_proba"] = 0.5615969597449075
+    res["default_iris_sparse"] = 0.42
+    res["default_digits"] = 0.4632665452337584
+    res["digits_n_calls"] = 9
+    res["default_digits_iterative"] = 0.4632665452337584
+    res["default_digits_binary"] = 0.978749241044323
+    res["default_digits_multilabel"] = 0.2652312930706514
+    res["default_digits_multilabel_proba"] = 0.8792680626296924
+
+    sk_mod = sklearn.neural_network.MLPClassifier
+    module = MLPClassifier
+    step_hyperparameter = {
+        'name': 'n_iter_',
+        'value': module.get_max_iter(),
+    }

--- a/test/test_pipeline/components/feature_preprocessing/test_kernel_pca.py
+++ b/test/test_pipeline/components/feature_preprocessing/test_kernel_pca.py
@@ -13,7 +13,6 @@ import sklearn.metrics
 
 class KernelPCAComponentTest(PreprocessingTestCase):
     @unittest.skipIf(sys.version_info < (3, 7), 'Random failures for Python < 3.7')
-    @pytest.mark.flaky()
     def test_default_configuration(self):
         transformation, original = _test_preprocessing(KernelPCA,
                                                        dataset='digits',
@@ -48,7 +47,7 @@ class KernelPCAComponentTest(PreprocessingTestCase):
             predictor = classifier.fit(X_train_trans, Y_train)
             predictions = predictor.predict(X_test_trans)
             accuracy = sklearn.metrics.accuracy_score(predictions, Y_test)
-            self.assertAlmostEqual(accuracy, 0.0903387703889586)
+            self.assertAlmostEqual(accuracy, 0.6775407779171895)
 
     @unittest.skip("Always returns float64")
     def test_preprocessing_dtype(self):

--- a/test/test_pipeline/components/regression/test_mlp.py
+++ b/test/test_pipeline/components/regression/test_mlp.py
@@ -13,6 +13,7 @@ class MLPComponentTest(BaseRegressionComponentTest):
     res["default_boston"] = 0.5572566941424424
     res["boston_n_calls"] = 9
     res["default_boston_iterative"] = 0.3991011585607287
+    res["default_boston_iterative_places"] = 2
     res["default_boston_sparse"] = -0.5023509031147615
     res["default_boston_iterative_sparse"] = -0.49785984132922323
     res["default_diabetes"] = 0.39632559079949414

--- a/test/test_pipeline/components/regression/test_mlp.py
+++ b/test/test_pipeline/components/regression/test_mlp.py
@@ -12,7 +12,7 @@ class MLPComponentTest(BaseRegressionComponentTest):
     res = dict()
     res["default_boston"] = 0.5572566941424424
     res["boston_n_calls"] = 9
-    res["default_boston_iterative"] = 0.4065338206433726
+    res["default_boston_iterative"] = 0.3991011585607287
     res["default_boston_sparse"] = -0.5023509031147615
     res["default_boston_iterative_sparse"] = -0.49785984132922323
     res["default_diabetes"] = 0.39632559079949414

--- a/test/test_pipeline/components/regression/test_mlp.py
+++ b/test/test_pipeline/components/regression/test_mlp.py
@@ -1,0 +1,29 @@
+import sklearn.neural_network
+
+from autosklearn.pipeline.components.regression.mlp import MLPRegressor
+
+from .test_base import BaseRegressionComponentTest
+
+
+class MLPComponentTest(BaseRegressionComponentTest):
+
+    __test__ = True
+
+    res = dict()
+    res["default_boston"] = 0.5572566941424424
+    res["boston_n_calls"] = 9
+    res["default_boston_iterative"] = 0.4065338206433726
+    res["default_boston_sparse"] = -0.5023509031147615
+    res["default_boston_iterative_sparse"] = -0.49785984132922323
+    res["default_diabetes"] = 0.39632559079949414
+    res["diabetes_n_calls"] = 9
+    res["default_diabetes_iterative"] = 0.4402964422631598
+    res["default_diabetes_sparse"] = 0.2283137551930371
+    res["default_diabetes_iterative_sparse"] = 0.27430032244279856
+
+    sk_mod = sklearn.neural_network.MLPRegressor
+    module = MLPRegressor
+    step_hyperparameter = {
+        'name': 'n_iter_',
+        'value': module.get_max_iter(),
+    }

--- a/test/test_pipeline/components/regression/test_mlp.py
+++ b/test/test_pipeline/components/regression/test_mlp.py
@@ -13,7 +13,7 @@ class MLPComponentTest(BaseRegressionComponentTest):
     res["default_boston"] = 0.5572566941424424
     res["boston_n_calls"] = 9
     res["default_boston_iterative"] = 0.3991011585607287
-    res["default_boston_iterative_places"] = 2
+    res["default_boston_iterative_places"] = 1
     res["default_boston_sparse"] = -0.5023509031147615
     res["default_boston_iterative_sparse"] = -0.49785984132922323
     res["default_diabetes"] = 0.39632559079949414

--- a/test/test_pipeline/components/regression/test_mlp.py
+++ b/test/test_pipeline/components/regression/test_mlp.py
@@ -12,15 +12,15 @@ class MLPComponentTest(BaseRegressionComponentTest):
     res = dict()
     res["default_boston"] = 0.5572566941424424
     res["boston_n_calls"] = 9
-    res["default_boston_iterative"] = 0.3991011585607287
+    res["default_boston_iterative"] = 0.5572566941424424
     res["default_boston_iterative_places"] = 1
     res["default_boston_sparse"] = -0.5023509031147615
-    res["default_boston_iterative_sparse"] = -0.49785984132922323
+    res["default_boston_iterative_sparse"] = -0.5023509031147615
     res["default_diabetes"] = 0.39632559079949414
     res["diabetes_n_calls"] = 9
-    res["default_diabetes_iterative"] = 0.4402964422631598
+    res["default_diabetes_iterative"] = 0.39632559079949414
     res["default_diabetes_sparse"] = 0.2283137551930371
-    res["default_diabetes_iterative_sparse"] = 0.27430032244279856
+    res["default_diabetes_iterative_sparse"] = 0.2283137551930371
 
     sk_mod = sklearn.neural_network.MLPRegressor
     module = MLPRegressor

--- a/test/test_pipeline/test_base.py
+++ b/test/test_pipeline/test_base.py
@@ -69,7 +69,7 @@ class BaseTest(unittest.TestCase):
         self.assertEqual(len(cs.get_hyperparameter("p1:__choice__").choices),
                          15)
         self.assertEqual(len(cs.get_hyperparameter("c:__choice__").choices),
-                         15)
+                         16)
         # for clause in sorted([str(clause) for clause in cs.forbidden_clauses]):
         #    print(clause)
         self.assertEqual(110, len(cs.forbidden_clauses))

--- a/test/test_pipeline/test_classification.py
+++ b/test/test_pipeline/test_classification.py
@@ -367,6 +367,8 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
                 cls.predict_proba(X_test)
             except MemoryError:
                 continue
+            except np.linalg.LinAlgError:
+                continue
             except ValueError as e:
                 if "Floating-point under-/overflow occurred at epoch" in \
                         e.args[0]:

--- a/test/test_pipeline/test_classification.py
+++ b/test/test_pipeline/test_classification.py
@@ -426,7 +426,7 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
             'feature_preprocessor:__choice__').choices), 13)
 
         hyperparameters = cs.get_hyperparameters()
-        self.assertEqual(165, len(hyperparameters))
+        self.assertEqual(164, len(hyperparameters))
 
         # for hp in sorted([str(h) for h in hyperparameters]):
         #    print hp

--- a/test/test_pipeline/test_classification.py
+++ b/test/test_pipeline/test_classification.py
@@ -426,7 +426,7 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
             'feature_preprocessor:__choice__').choices), 13)
 
         hyperparameters = cs.get_hyperparameters()
-        self.assertEqual(152, len(hyperparameters))
+        self.assertEqual(165, len(hyperparameters))
 
         # for hp in sorted([str(h) for h in hyperparameters]):
         #    print hp

--- a/test/test_pipeline/test_classification.py
+++ b/test/test_pipeline/test_classification.py
@@ -421,7 +421,7 @@ class SimpleClassificationPipelineTest(unittest.TestCase):
         self.assertEqual(len(cs.get_hyperparameter(
             'data_preprocessing:numerical_transformer:rescaling:__choice__').choices), 6)
         self.assertEqual(len(cs.get_hyperparameter(
-            'classifier:__choice__').choices), 15)
+            'classifier:__choice__').choices), 16)
         self.assertEqual(len(cs.get_hyperparameter(
             'feature_preprocessor:__choice__').choices), 13)
 

--- a/test/test_pipeline/test_regression.py
+++ b/test/test_pipeline/test_regression.py
@@ -193,6 +193,8 @@ class SimpleRegressionPipelineTest(unittest.TestCase):
                 cls.predict(X_test)
             except MemoryError:
                 continue
+            except np.linalg.LinAlgError:
+                continue
             except ValueError as e:
                 if "Floating-point under-/overflow occurred at epoch" in \
                         e.args[0]:

--- a/test/test_pipeline/test_regression.py
+++ b/test/test_pipeline/test_regression.py
@@ -277,7 +277,7 @@ class SimpleRegressionPipelineTest(unittest.TestCase):
         self.assertIsInstance(cs, ConfigurationSpace)
         conditions = cs.get_conditions()
         hyperparameters = cs.get_hyperparameters()
-        self.assertEqual(140, len(hyperparameters))
+        self.assertEqual(152, len(hyperparameters))
         self.assertEqual(len(hyperparameters) - 6, len(conditions))
 
     def test_get_hyperparameter_search_space_include_exclude_models(self):


### PR DESCRIPTION
task|acc|auc|balacc|logloss|mae|r2|rmse
Australian|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan
blood-transfusion|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan
car|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan
christine|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan
cnae-9|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan
credit-g|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan
dilbert|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan
fabert|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan
jasmine|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan
kc1|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan
kr-vs-kp|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan
mfeat-factors|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan
phoneme|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan
segment|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan
sylvine|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan
vehicle|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#353536](https://via.placeholder.com/15/#353536/000000?text=+) 0.0|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan|![#52544f](https://via.placeholder.com/15/#52544f/000000?text=+) nan